### PR TITLE
fix(router): error handling when API or docs are down

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -11,6 +11,7 @@
 	# Redirect all files to / (except API) and let Vue handle the routing
 	@try_files {
 		not path /api/*
+		not path /docs/*
 		file {
 			try_files {path} /
 		}
@@ -22,7 +23,6 @@
 	respond /api/* "Bad Gateway (/api reached frontend)" 502 {
 		close
 	}
-
 
 	log error_log {
 		output stderr

--- a/Caddyfile
+++ b/Caddyfile
@@ -7,5 +7,24 @@
 	file_server
 
 	# Vue router support https://router.vuejs.org/guide/essentials/history-mode.html#Caddy-v2
-	try_files {path} /
+	# Using expanded form https://caddyserver.com/docs/caddyfile/directives/try_files#expanded-form
+	# Redirect all files to / (except API) and let Vue handle the routing
+	@try_files {
+		not path /api/*
+		file {
+			try_files {path} /
+		}
+	}
+	rewrite @try_files {file_match.relative}
+
+	# API requests should never reach this frontend server
+	# If they do, fail explicitly with a bad gateway error
+	handle_path /api/* {
+		respond 502
+	}
+
+	log error_log {
+		output stderr
+		level ERROR
+	}
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -19,9 +19,10 @@
 
 	# API requests should never reach this frontend server
 	# If they do, fail explicitly with a bad gateway error
-	handle_path /api/* {
-		respond 502
+	respond /api/* "Bad Gateway (/api reached frontend)" 502 {
+		close
 	}
+
 
 	log error_log {
 		output stderr


### PR DESCRIPTION
when the reims2-backend is down, the traefik proxy redirects /api to the frontend container, which then returns index.html, which gets cached. this corrupts REIMS2 for a longer time.

this is now prevented, by using caddy inside the frontend container to reject those requests